### PR TITLE
モバイル版のgMenuにおいて、MENUと書かれた部分を押したときのみ、onclickが呼ばれるように変更

### DIFF
--- a/header.php
+++ b/header.php
@@ -84,9 +84,9 @@ if ($gMenu) {
 // ナビのHTMLを一旦変数に格納
 $gMenuHtml = '
 <!-- [ #gMenu ] -->
-<div id="gMenu" class="itemClose" onclick="showHide(\'gMenu\');">
+<div id="gMenu" class="itemClose">
 <div id="gMenuInner" class="innerBox">
-<h3 class="assistive-text"><span>MENU</span></h3>
+<h3 class="assistive-text" onclick="showHide(\'gMenu\');"><span>MENU</span></h3>
 <div class="skip-link screen-reader-text">
 	<a href="#content" title="'.__('Skip menu', 'biz-vektor').'">'.__('Skip menu', 'biz-vektor').'</a>
 </div>'."\n";


### PR DESCRIPTION
モバイル版のgMenuを展開中に、メニューの項目(MENUと書かれた部分以外のところ) をクリックしても、
onclickが呼ばれておりました。このため、画面切り替わり前にメニューが閉じてしまい、
画面がちらつくように見えました。

本pull requestは、この件の修正です。
ご確認をよろしくお願い致します。