### PR TITLE
Syntax errorの修正

### DIFF
--- a/js/master.js
+++ b/js/master.js
@@ -159,7 +159,7 @@ document.addEventListener("DOMContentLoaded",function(){
 	//
 	// <a href="#***">の場合、スクロール処理を追加
 	//
-	jQuery('a[href*=#]').click(function() {
+	jQuery('a[href*=\\#]').click(function() {
 		if (location.pathname.replace(/^\//,'') == this.pathname.replace(/^\//,'') && location.hostname == this.hostname) {
 			var $target = jQuery(this.hash);
 			if(!this.hash.slice(1)){return;}


### PR DESCRIPTION
WordPress 4.5で、JavaScript ライブラリの更新があったのでエラーが出ます。

#特殊文字をエスケープ